### PR TITLE
enforce ordering in TwoNestedMap.Entry's toString 

### DIFF
--- a/src/main/java/com/liveramp/commons/collections/nested_map/TwoKeyTuple.java
+++ b/src/main/java/com/liveramp/commons/collections/nested_map/TwoKeyTuple.java
@@ -17,9 +17,6 @@ public class TwoKeyTuple<K1, K2> implements Serializable{
   public List toList() {
     return Lists.newArrayList(k1, k2);
   }
-  public Set toSet() {
-    return Sets.newHashSet(k1, k2);
-  }
 
   @Override
   public boolean equals(Object o) {

--- a/src/main/java/com/liveramp/commons/collections/nested_map/TwoNestedMap.java
+++ b/src/main/java/com/liveramp/commons/collections/nested_map/TwoNestedMap.java
@@ -196,7 +196,7 @@ public class TwoNestedMap<K1, K2, V> implements Iterable<TwoNestedMap.Entry<K1, 
 
     @Override
     public String toString() {
-      return String.format("%s -> %s", keyTuple.toSet(), value);
+      return String.format("%s -> %s", keyTuple.toList(), value);
     }
 
   }


### PR DESCRIPTION
Right now the string for a `TwoNestedMap.Entry` would show as either `[k1, k2] -> value` or `[k2, k1] -> value` depending on the set ordering. 

This PR:
- forces `toString` to only return `[k1, k2] -> value`
- removes the unused `toSet` method